### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/openapi-maven-ci.yml
+++ b/.github/workflows/openapi-maven-ci.yml
@@ -9,10 +9,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v4
+    - name: Set up Adopt OpenJDK 21
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+        distribution: adopt
+        java-version: '21'
+        cache: maven
     - name: Build with Maven
       run: mvn -B package

--- a/.github/workflows/openapi-maven-release.yml
+++ b/.github/workflows/openapi-maven-release.yml
@@ -8,20 +8,21 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v4
+    - name: Set up Adopt OpenJDK 21
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+        distribution: adopt
+        java-version: '21'
+        cache: maven
         server-id: ossrh
-        server-username: OPENAPI_OSSRH_USERNAME
-        server-password: OPENAPI_OSSRH_TOKEN
+        server-username: ${{ secrets.OPENAPI_OSSRH_USERNAME }}
+        server-password: ${{ secrets.OPENAPI_OSSRH_TOKEN }}
         gpg-private-key: ${{ secrets.OPENAPI_OSSRH_GPG_SECRET_KEY }}
-        gpg-passphrase: OPENAPI_OSSRH_GPG_SECRET_KEY_PASSWORD
+        gpg-passphrase: ${{ secrets.OPENAPI_OSSRH_GPG_SECRET_KEY_PASSWORD }}
     - name: Set release version in pom.xml
       run: |
-         VERSION=`cut -d/ -f3 <<< $GITHUB_REF`
-         VERSION=${VERSION:1}
+         VERSION=${GITHUB_REF_NAME:1}
          mvn -B versions:set -DnewVersion=$VERSION
     - name: Build with Maven
       run: |
@@ -33,35 +34,11 @@ jobs:
         echo "OPENAPI_ARTIFACT_FILE=$OPENAPI_ARTIFACT_FILE" >> $GITHUB_ENV
         echo "OPENAPI_ARTIFACT_NAME=`basename $OPENAPI_ARTIFACT_FILE`" >> $GITHUB_ENV
     - name: Create GitHub release
-      id: create-release
-      uses: actions/create-release@v1
+      run: |
+        gh release create ${GITHUB_REF} --draft --title "Release ${GITHUB_REF_NAME}" --notes "Changes:
+        - [placeholder]" "${SWAGGER_ARTIFACT_FILE}#${SWAGGER_ARTIFACT_NAME}" "${OPENAPI_ARTIFACT_FILE}#${OPENAPI_ARTIFACT_NAME}"
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        body: |
-            Changes:
-            - [placeholder]
-        draft: true
-    - name: Upload swagger.zip release asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create-release.outputs.upload_url }}
-        asset_path: ${{ env.SWAGGER_ARTIFACT_FILE }}
-        asset_name: ${{ env.SWAGGER_ARTIFACT_NAME }}
-        asset_content_type: application/zip
-    - name: Upload openapi.zip release asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create-release.outputs.upload_url }}
-        asset_path: ${{ env.OPENAPI_ARTIFACT_FILE }}
-        asset_name: ${{ env.OPENAPI_ARTIFACT_NAME }}
-        asset_content_type: application/zip
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish to Maven Central
       env:
         OPENAPI_OSSRH_USERNAME: ${{ secrets.OPENAPI_OSSRH_USERNAME }}


### PR DESCRIPTION
See https://github.com/belgif/rest-guide/issues/170.

* upgrade to actions/checkout@v4
* upgrade to actions/setup-java@v4 (and JDK21 + enable maven cache)
* consistently use ${{ secrets.x }}
* use $GITHUB_REF_NAME
* replace actions/create-release@v1 and actions/upload-release-asset@v1 by GitHub CLI "gh release create"
* add dependabot.yml config for keeping github-actions up-to-date