### PR TITLE
Fix openapi-maven-release.yml

### DIFF
--- a/.github/workflows/openapi-maven-release.yml
+++ b/.github/workflows/openapi-maven-release.yml
@@ -16,10 +16,10 @@ jobs:
         java-version: '21'
         cache: maven
         server-id: ossrh
-        server-username: ${{ secrets.OPENAPI_OSSRH_USERNAME }}
-        server-password: ${{ secrets.OPENAPI_OSSRH_TOKEN }}
+        server-username: OPENAPI_OSSRH_USERNAME
+        server-password: OPENAPI_OSSRH_TOKEN
         gpg-private-key: ${{ secrets.OPENAPI_OSSRH_GPG_SECRET_KEY }}
-        gpg-passphrase: ${{ secrets.OPENAPI_OSSRH_GPG_SECRET_KEY_PASSWORD }}
+        gpg-passphrase: OPENAPI_OSSRH_GPG_SECRET_KEY_PASSWORD
     - name: Set release version in pom.xml
       run: |
          VERSION=${GITHUB_REF_NAME:1}


### PR DESCRIPTION
Partial revert of https://github.com/belgif/openapi-location/pull/9.

server-username, server-password and gpg-passphrase are environment variable names.